### PR TITLE
feat: improve open AR processing checks and rejected invoice handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,20 @@ cp .env.example .env
 pip install -r requirements.txt
 ```
 
-### 4. Run pipeline
+### 4. Run the pipeline
 
 ```bash
 python src/main.py
 ```
+
+### 5. Issue more invoices without resetting PostgreSQL
+
+```bash
+python src/issue_new_invoices.py --count 10
+python src/main.py
+```
+
+The helper script inserts fresh rows into `issued_invoices` with new document numbers and current timestamps, so the incremental pipeline picks them up on the next run.
 
 ---
 

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE public.currency (
 );
 
 CREATE TABLE public.issued_invoices (
-    doc_number       VARCHAR(100) PRIMARY KEY,
+    doc_number       VARCHAR(100) NOT NULL,
     customer_id      CHAR(8) NOT NULL REFERENCES public.customers(customer_id) ON DELETE CASCADE,
     contract_number  VARCHAR(100),
     issue_date       DATE NOT NULL,
@@ -35,12 +35,14 @@ CREATE TABLE public.issued_invoices (
     created_at       TIMESTAMPTZ DEFAULT NOW(),
     document_type    VARCHAR(20) NOT NULL DEFAULT 'INVOICE',
     type             TEXT DEFAULT 'Leasing',
-    doc_reference    VARCHAR(100)
+    doc_reference    VARCHAR(100),
+    PRIMARY KEY (doc_number, customer_id, document_type)
 );
 
 CREATE TABLE public.open_ar (
-    doc_number          VARCHAR(100) PRIMARY KEY,
+    doc_number          VARCHAR(100) NOT NULL,
     customer_id         CHAR(8) NOT NULL,
+    document_type       VARCHAR(20) NOT NULL,
     contract_number     VARCHAR(100),
     issue_date          DATE NOT NULL,
     due_date            DATE NOT NULL,
@@ -54,7 +56,24 @@ CREATE TABLE public.open_ar (
     created_at          TIMESTAMP NOT NULL,
     last_updt_time      TIMESTAMP DEFAULT NOW(),
     collector           VARCHAR(255),
-    last_reminder_dt    TIMESTAMP
+    last_reminder_dt    TIMESTAMP,
+    PRIMARY KEY (doc_number, customer_id, document_type)
+);
+
+CREATE TABLE public.rejected_invoices (
+    rejected_invoice_id SERIAL PRIMARY KEY,
+    doc_number          VARCHAR(100),
+    customer_id         CHAR(8),
+    document_type       VARCHAR(20),
+    contract_number     VARCHAR(100),
+    issue_date          DATE,
+    due_date            DATE,
+    amount              NUMERIC(12, 2),
+    currency_code       VARCHAR(10),
+    rejection_stage     VARCHAR(100) NOT NULL,
+    rejection_reason    TEXT NOT NULL,
+    created_at          TIMESTAMPTZ,
+    rejected_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE public.process_runs (

--- a/sql/02_seed.sql
+++ b/sql/02_seed.sql
@@ -18,7 +18,8 @@ INSERT INTO public.customers (
 )
 VALUES
     ('CUST0001', 'Acme Corp', '12.345.678/0001-99', 'Retail', 'Brazil', 1),
-    ('CUST0002', 'Globex Inc', '98.765.432/0001-11', 'Manufacturing', 'USA', 2);
+    ('CUST0002', 'Globex Inc', '98.765.432/0001-11', 'Manufacturing', 'USA', 2),
+    ('CUST0003', 'No Collector LLC', '11.222.333/0001-44', 'Services', 'Canada', NULL);
 
 
 INSERT INTO public.currency (
@@ -65,4 +66,72 @@ VALUES
         'EUR',
         'Industrial equipment lease',
         'INVOICE'
-    );
+    ),
+    (
+        'INV-1003',
+        'CUST0003',
+        'CTR-003',
+        '2026-01-10',
+        '2026-02-20',
+        4200.00,
+        'USD',
+        'Valid currency with missing collector assignment',
+        'INVOICE'
+    ),
+    (
+        'INV-1004',
+        'CUST0001',
+        'CTR-004',
+        '2026-01-10',
+        '2026-02-25',
+        9100.00,
+        'CAD',
+        'Unsupported currency used to test rejected invoices',
+        'INVOICE'
+    ),
+    ('INV-1005', 'CUST0001', 'CTR-005', '2026-01-11', '2026-02-10', 1250.00, 'USD', 'Monthly service invoice', 'INVOICE'),
+    ('INV-1006', 'CUST0002', 'CTR-006', '2026-01-12', '2026-02-11', 2325.50, 'EUR', 'Equipment rental invoice', 'INVOICE'),
+    ('INV-1007', 'CUST0003', 'CTR-007', '2026-01-13', '2026-02-12', 1780.00, 'BRL', 'Collector assignment check invoice', 'INVOICE'),
+    ('INV-1008', 'CUST0001', 'CTR-008', '2026-01-14', '2026-02-13', 6400.00, 'USD', 'Quarterly maintenance invoice', 'INVOICE'),
+    ('INV-1009', 'CUST0002', 'CTR-009', '2026-01-15', '2026-02-14', 3150.75, 'EUR', 'Parts replacement invoice', 'INVOICE'),
+    ('INV-1010', 'CUST0001', 'CTR-010', '2026-01-16', '2026-02-15', 2220.00, 'JPY', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1011', 'CUST0003', 'CTR-011', '2026-01-17', '2026-02-16', 4890.00, 'USD', 'Unassigned collector recurring invoice', 'INVOICE'),
+    ('INV-1012', 'CUST0002', 'CTR-012', '2026-01-18', '2026-02-17', 5120.00, 'BRL', 'Regional services invoice', 'INVOICE'),
+    ('INV-1013', 'CUST0001', 'CTR-013', '2026-01-19', '2026-02-18', 7600.00, 'EUR', 'Lease adjustment invoice', 'INVOICE'),
+    ('INV-1014', 'CUST0002', 'CTR-014', '2026-01-20', '2026-02-19', 2890.00, 'USD', 'Support package invoice', 'INVOICE'),
+    ('INV-1015', 'CUST0003', 'CTR-015', '2026-01-21', '2026-02-20', 1980.00, 'BRL', 'Collector review sample', 'INVOICE'),
+    ('INV-1016', 'CUST0001', 'CTR-016', '2026-01-22', '2026-02-21', 8425.00, 'USD', 'Annual licensing invoice', 'INVOICE'),
+    ('INV-1017', 'CUST0002', 'CTR-017', '2026-01-23', '2026-02-22', 3650.00, 'CAD', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1018', 'CUST0001', 'CTR-018', '2026-01-24', '2026-02-23', 4510.00, 'EUR', 'Implementation invoice', 'INVOICE'),
+    ('INV-1019', 'CUST0003', 'CTR-019', '2026-01-25', '2026-02-24', 2740.00, 'USD', 'Collector assignment exception invoice', 'INVOICE'),
+    ('INV-1020', 'CUST0002', 'CTR-020', '2026-01-26', '2026-02-25', 6300.00, 'BRL', 'Manufacturing support invoice', 'INVOICE'),
+    ('INV-1021', 'CUST0001', 'CTR-021', '2026-01-27', '2026-02-26', 915.00, 'USD', 'Small balance invoice', 'INVOICE'),
+    ('INV-1022', 'CUST0002', 'CTR-022', '2026-01-28', '2026-02-27', 7100.00, 'EUR', 'Large contract invoice', 'INVOICE'),
+    ('INV-1023', 'CUST0003', 'CTR-023', '2026-01-29', '2026-02-28', 3325.00, 'BRL', 'Unassigned collector service invoice', 'INVOICE'),
+    ('INV-1024', 'CUST0001', 'CTR-024', '2026-01-30', '2026-03-01', 2675.00, 'USD', 'Month-end recurring invoice', 'INVOICE'),
+    ('INV-1025', 'CUST0002', 'CTR-025', '2026-01-31', '2026-03-02', 4010.00, 'GBP', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1026', 'CUST0001', 'CTR-026', '2026-02-01', '2026-03-03', 5580.00, 'EUR', 'Expansion project invoice', 'INVOICE'),
+    ('INV-1027', 'CUST0003', 'CTR-027', '2026-02-02', '2026-03-04', 1895.00, 'USD', 'Collector exception follow-up invoice', 'INVOICE'),
+    ('INV-1028', 'CUST0002', 'CTR-028', '2026-02-03', '2026-03-05', 9475.00, 'BRL', 'Capital equipment invoice', 'INVOICE'),
+    ('INV-1029', 'CUST0001', 'CTR-029', '2026-02-04', '2026-03-06', 1180.00, 'USD', 'Subscription adjustment invoice', 'INVOICE'),
+    ('INV-1030', 'CUST0002', 'CTR-030', '2026-02-05', '2026-03-07', 6800.00, 'EUR', 'Transport services invoice', 'INVOICE'),
+    ('INV-1031', 'CUST0003', 'CTR-031', '2026-02-06', '2026-03-08', 2450.00, 'BRL', 'Collector gap validation invoice', 'INVOICE'),
+    ('INV-1032', 'CUST0001', 'CTR-032', '2026-02-07', '2026-03-09', 7990.00, 'USD', 'Upgrade services invoice', 'INVOICE'),
+    ('INV-1033', 'CUST0002', 'CTR-033', '2026-02-08', '2026-03-10', 1560.00, 'AUD', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1034', 'CUST0001', 'CTR-034', '2026-02-09', '2026-03-11', 3860.00, 'EUR', 'Consulting package invoice', 'INVOICE'),
+    ('INV-1035', 'CUST0003', 'CTR-035', '2026-02-10', '2026-03-12', 4720.00, 'USD', 'Collector assignment control invoice', 'INVOICE'),
+    ('INV-1036', 'CUST0002', 'CTR-036', '2026-02-11', '2026-03-13', 5290.00, 'BRL', 'Renewal charge invoice', 'INVOICE'),
+    ('INV-1037', 'CUST0001', 'CTR-037', '2026-02-12', '2026-03-14', 2140.00, 'USD', 'Usage fee invoice', 'INVOICE'),
+    ('INV-1038', 'CUST0002', 'CTR-038', '2026-02-13', '2026-03-15', 6440.00, 'EUR', 'Regional contract invoice', 'INVOICE'),
+    ('INV-1039', 'CUST0003', 'CTR-039', '2026-02-14', '2026-03-16', 3580.00, 'BRL', 'Missing collector validation invoice', 'INVOICE'),
+    ('INV-1040', 'CUST0001', 'CTR-040', '2026-02-15', '2026-03-17', 9050.00, 'USD', 'Premium service invoice', 'INVOICE'),
+    ('INV-1041', 'CUST0002', 'CTR-041', '2026-02-16', '2026-03-18', 2980.00, 'MXN', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1042', 'CUST0001', 'CTR-042', '2026-02-17', '2026-03-19', 4875.00, 'EUR', 'Contract milestone invoice', 'INVOICE'),
+    ('INV-1043', 'CUST0003', 'CTR-043', '2026-02-18', '2026-03-20', 2670.00, 'USD', 'Unassigned collector invoice sample', 'INVOICE'),
+    ('INV-1044', 'CUST0002', 'CTR-044', '2026-02-19', '2026-03-21', 7440.00, 'BRL', 'Supply chain services invoice', 'INVOICE'),
+    ('INV-1045', 'CUST0001', 'CTR-045', '2026-02-20', '2026-03-22', 1320.00, 'USD', 'Late cycle service invoice', 'INVOICE'),
+    ('INV-1046', 'CUST0002', 'CTR-046', '2026-02-21', '2026-03-23', 8210.00, 'EUR', 'Enterprise renewal invoice', 'INVOICE'),
+    ('INV-1047', 'CUST0003', 'CTR-047', '2026-02-22', '2026-03-24', 3090.00, 'BRL', 'Collector assignment audit invoice', 'INVOICE'),
+    ('INV-1048', 'CUST0001', 'CTR-048', '2026-02-23', '2026-03-25', 5560.00, 'USD', 'Operational services invoice', 'INVOICE'),
+    ('INV-1049', 'CUST0002', 'CTR-049', '2026-02-24', '2026-03-26', 4700.00, 'CHF', 'Unsupported currency rejection sample', 'INVOICE'),
+    ('INV-1050', 'CUST0003', 'CTR-050', '2026-02-25', '2026-03-27', 3925.00, 'EUR', 'Collector assignment final sample', 'INVOICE');

--- a/src/etl/load/open_ar.py
+++ b/src/etl/load/open_ar.py
@@ -2,23 +2,27 @@ from sqlalchemy import text
 from config.db import engine  
 
 def insert_open_ar(df):
-    """Insert transformed invoices into open_ar table, ignore duplicates based on doc_number"""
+    """Insert transformed invoices into open_ar and ignore duplicate business keys."""
+    if df.empty:
+        return 0
+
     df_records = df.to_dict(orient="records")
 
     query = """
     INSERT INTO public.open_ar (
-        doc_number, customer_id, contract_number,
+        doc_number, customer_id, document_type, contract_number,
         issue_date, due_date,
         total_amount, balance_amount, amount_usd, balance_amount_usd,
         aging_group, status, comment, created_at, collector
     ) VALUES (
-        :doc_number, :customer_id, :contract_number,
+        :doc_number, :customer_id, :document_type, :contract_number,
         :issue_date, :due_date,
         :total_amount, :balance_amount, :amount_usd, :balance_amount_usd,
         :aging_group, :status, :comment, :created_at, :collector
     )
-    ON CONFLICT (doc_number) DO NOTHING;
+    ON CONFLICT (doc_number, customer_id, document_type) DO NOTHING;
     """
 
     with engine.begin() as connection:
-        connection.execute(text(query), df_records)   # automatic executemany 
+        result = connection.execute(text(query), df_records)
+        return result.rowcount or 0

--- a/src/etl/load/rejected_invoices.py
+++ b/src/etl/load/rejected_invoices.py
@@ -1,0 +1,41 @@
+from sqlalchemy import text
+
+from config.db import engine
+
+
+def insert_rejected_invoices(df):
+    """Persist invoices rejected during transformation and return inserted row count."""
+    if df.empty:
+        return 0
+
+    query = """
+    INSERT INTO public.rejected_invoices (
+        doc_number,
+        customer_id,
+        document_type,
+        contract_number,
+        issue_date,
+        due_date,
+        amount,
+        currency_code,
+        rejection_stage,
+        rejection_reason,
+        created_at
+    ) VALUES (
+        :doc_number,
+        :customer_id,
+        :document_type,
+        :contract_number,
+        :issue_date,
+        :due_date,
+        :amount,
+        :currency_code,
+        :rejection_stage,
+        :rejection_reason,
+        :created_at
+    )
+    """
+
+    with engine.begin() as connection:
+        result = connection.execute(text(query), df.to_dict(orient="records"))
+        return result.rowcount or 0

--- a/src/etl/pipelines/build_open_ar.py
+++ b/src/etl/pipelines/build_open_ar.py
@@ -6,6 +6,7 @@ from etl.extract.collectors import get_collectors_map
 from etl.transform.invoices import transform_invoices
 
 from etl.load.open_ar import insert_open_ar
+from etl.load.rejected_invoices import insert_rejected_invoices
 from etl.load.log_run import log_run
 
 
@@ -35,7 +36,7 @@ def build_open_ar():
         if new_invoices.empty:
             print("[INFO] No new invoices found. Nothing to insert into open_ar.")
             print()
-            log_run(PROCESS_NAME, "0 invoices inserted")
+            log_run(PROCESS_NAME, "0 invoices inserted; 0 invoices rejected")
             print("[SUCCESS] Process run logged")
             print("[END] Pipeline finished successfully")
             print()
@@ -43,27 +44,58 @@ def build_open_ar():
             return
 
         currency_rates = get_currency_rates()
-        print(f"[EXTRACT] Currency rates loaded: {len(currency_rates)}")
-
         collectors_map = get_collectors_map()
-        print(f"[EXTRACT] Collectors loaded: {len(collectors_map)}")
-        print()
 
-        df_transformed = transform_invoices(
+        df_transformed, df_rejected = transform_invoices(
             new_invoices,
             currency_rates,
             collectors_map,
         )
         print(f"[TRANSFORM] Invoices transformed: {len(df_transformed)}")
+        print(f"[TRANSFORM] Invoices rejected: {len(df_rejected)}")
         print()
 
-        count_processed = len(df_transformed)
-        info = f"{count_processed} new invoices inserted"
+        inserted_count = insert_open_ar(df_transformed)
+        rejected_count = insert_rejected_invoices(df_rejected)
 
-        insert_open_ar(df_transformed)
-        print(f"[LOAD] Open AR updated: {count_processed} rows inserted")
+        missing_currency_codes = sorted(
+            set(new_invoices["currency_code"]) - set(currency_rates.keys())
+        )
+        all_currency_found = not missing_currency_codes
+        collector_assignments = new_invoices["customer_id"].map(collectors_map)
+        missing_collector_customers = sorted(
+            set(new_invoices.loc[collector_assignments.isna(), "customer_id"])
+        )
+        all_collectors_assigned = not missing_collector_customers
+
+        print(
+            "[CHECK] Currency found for all invoice currencies: "
+            f"{'YES' if all_currency_found else 'NO'}"
+        )
+        if missing_currency_codes:
+            print(f"[CHECK] Missing currency codes: {', '.join(missing_currency_codes)}")
+
+        print(
+            "[CHECK] All collectors assigned correctly: "
+            f"{'YES' if all_collectors_assigned else 'NO'}"
+        )
+        if missing_collector_customers:
+            print(
+                "[CHECK] Customers without collectors: "
+                f"{', '.join(missing_collector_customers)}"
+            )
         print()
 
+        print(f"[LOAD] Open AR updated: {inserted_count} rows inserted")
+        print(f"[LOAD] Rejected invoices stored: {rejected_count} rows inserted")
+        print()
+
+        info = (
+            f"{inserted_count} invoices inserted; "
+            f"{rejected_count} invoices rejected; "
+            f"currency_complete={'yes' if all_currency_found else 'no'}; "
+            f"collectors_complete={'yes' if all_collectors_assigned else 'no'}"
+        )
         log_run(PROCESS_NAME, info)
         print("[SUCCESS] Process run logged")
         print("[END] Pipeline finished successfully")

--- a/src/etl/transform/invoices.py
+++ b/src/etl/transform/invoices.py
@@ -2,8 +2,17 @@ from etl.transform.aging import calculate_aging
 
 
 def transform_invoices(df_invoices, currency_rates, collectors_map):
-    """Transform issued_invoices df to match open_ar structure and add necessary columns"""
+    """Transform issued invoices and split rows that cannot be completed safely."""
     df = df_invoices.copy()
+
+    df["usd_rate"] = df["currency_code"].map(currency_rates)
+    rejected = df[df["usd_rate"].isna()].copy()
+    rejected["rejection_stage"] = "currency_lookup"
+    rejected["rejection_reason"] = rejected["currency_code"].map(
+        lambda code: f"Missing USD currency rate for '{code}'"
+    )
+
+    df = df[df["usd_rate"].notna()].copy()
 
     # create new columns
     df["total_amount"] = df["amount"]
@@ -12,7 +21,6 @@ def transform_invoices(df_invoices, currency_rates, collectors_map):
     df["comment"] = None
 
     # convert amounts to USD and create usd columns
-    df["usd_rate"] = df["currency_code"].map(currency_rates)
     df["amount_usd"] = df["amount"] * df["usd_rate"]
     df["balance_amount_usd"] = df["balance_amount"] * df["usd_rate"]
 
@@ -22,10 +30,11 @@ def transform_invoices(df_invoices, currency_rates, collectors_map):
     # add collector column
     df["collector"] = df["customer_id"].map(collectors_map).fillna("Unassigned")
 
-    return df[
+    transformed = df[
         [
             "doc_number",
             "customer_id",
+            "document_type",
             "contract_number",
             "issue_date",
             "due_date",
@@ -40,3 +49,21 @@ def transform_invoices(df_invoices, currency_rates, collectors_map):
             "collector",
         ]
     ]
+
+    rejected = rejected[
+        [
+            "doc_number",
+            "customer_id",
+            "document_type",
+            "contract_number",
+            "issue_date",
+            "due_date",
+            "amount",
+            "currency_code",
+            "rejection_stage",
+            "rejection_reason",
+            "created_at",
+        ]
+    ]
+
+    return transformed, rejected

--- a/src/issue_new_invoices.py
+++ b/src/issue_new_invoices.py
@@ -1,0 +1,123 @@
+import argparse
+from datetime import date, timedelta
+from itertools import cycle
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from config.db import engine
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Insert fresh issued invoices so the incremental pipeline can run again."
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=5,
+        help="Number of invoices to issue. Default: 5.",
+    )
+    parser.add_argument(
+        "--document-type",
+        default="INVOICE",
+        help="Document type stored with the new invoices. Default: INVOICE.",
+    )
+    return parser.parse_args()
+
+
+def get_seed_values():
+    customers_query = """
+    SELECT customer_id
+    FROM public.customers
+    ORDER BY customer_id
+    """
+    currencies_query = """
+    SELECT DISTINCT currency_code
+    FROM public.currency
+    ORDER BY currency_code
+    """
+
+    with engine.connect() as connection:
+        customers = [row.customer_id for row in connection.execute(text(customers_query))]
+        currencies = [row.currency_code for row in connection.execute(text(currencies_query))]
+
+    if not customers:
+        raise RuntimeError("No customers found. Seed or create customers before issuing invoices.")
+    if not currencies:
+        raise RuntimeError("No currencies found. Seed or create currency rates before issuing invoices.")
+
+    return customers, currencies
+
+
+def build_invoice_rows(count, document_type):
+    customers, currencies = get_seed_values()
+    today = date.today()
+    due_date = today + timedelta(days=30)
+    customer_cycle = cycle(customers)
+    currency_cycle = cycle(currencies)
+
+    rows = []
+    for index in range(1, count + 1):
+        token = uuid4().hex[:10].upper()
+        rows.append(
+            {
+                "doc_number": f"INV-AUTO-{token}",
+                "customer_id": next(customer_cycle),
+                "contract_number": f"CTR-AUTO-{index:03d}",
+                "issue_date": today,
+                "due_date": due_date,
+                "amount": 1000 + (index * 125),
+                "currency_code": next(currency_cycle),
+                "description": f"Auto-issued invoice batch item {index}",
+                "document_type": document_type,
+            }
+        )
+
+    return rows
+
+
+def insert_invoices(rows):
+    query = """
+    INSERT INTO public.issued_invoices (
+        doc_number,
+        customer_id,
+        contract_number,
+        issue_date,
+        due_date,
+        amount,
+        currency_code,
+        description,
+        document_type
+    ) VALUES (
+        :doc_number,
+        :customer_id,
+        :contract_number,
+        :issue_date,
+        :due_date,
+        :amount,
+        :currency_code,
+        :description,
+        :document_type
+    )
+    """
+
+    with engine.begin() as connection:
+        result = connection.execute(text(query), rows)
+        return result.rowcount or 0
+
+
+def main():
+    args = parse_args()
+    if args.count < 1:
+        raise ValueError("--count must be at least 1.")
+
+    rows = build_invoice_rows(args.count, args.document_type)
+    inserted_count = insert_invoices(rows)
+
+    print(f"[ISSUE] New invoices inserted: {inserted_count}")
+    print("[ISSUE] Run `python src/main.py` to process them into open_ar.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What this PR does
Improves the Open AR pipeline with stronger idempotency, rejected invoice handling, clearer process checks, richer seed data, and a helper script to issue new invoices for repeatable local testing.

# Implementation details
- Uses `doc_number + customer_id + document_type` as the invoice business key for `issued_invoices` and `open_ar`, and prevents duplicate inserts with the same composite key.
- Adds `rejected_invoices` storage and routes invoices with missing currency rates there during transformation.
- Replaces low-value extract counts in the pipeline output with process checks for currency coverage, collector assignment completeness, inserted rows, and rejected rows.
- Expands seed data to 50 invoices, including unsupported currency cases and unassigned collector cases, and adds `issue_new_invoices.py` plus README guidance for rerunning the pipeline without resetting the database.

